### PR TITLE
Add .env files and update axios calls to use the new root URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_ROOT_URL = "http://dkan.localtest.me/api/1"

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_ROOT_URL = "/api/1"

--- a/src/components/Resource/index.jsx
+++ b/src/components/Resource/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import {
   Resource,
   DataTable,
@@ -8,7 +8,7 @@ import {
 
 const ResourceTemplate = ({ resource }) => {
   const format = resource.hasOwnProperty('data') && resource.data.hasOwnProperty('format') ? resource.data.format : 'unknown';
-  const rootURL = `http://dkan/api/1/`;
+  const rootURL = `${process.env.REACT_APP_ROOT_URL}/`;
   return (
     <div id={`resource_${resource.identifier}`}>
       {format.toLowerCase() === 'csv'

--- a/src/templates/api/index.jsx
+++ b/src/templates/api/index.jsx
@@ -6,7 +6,7 @@ const ApiDocsFull = ({ path }) => (
   <div className={`dc-page ${config.container}`}>
     <div className="page-content">
       {typeof window !== `undefined` && (
-        <ApiDocs endpoint={'http://dkan/api/1'} />
+        <ApiDocs endpoint={process.env.REACT_APP_ROOT_URL} />
       )}
     </div>
   </div>

--- a/src/templates/dataset/index.jsx
+++ b/src/templates/dataset/index.jsx
@@ -24,7 +24,7 @@ const Dataset = ({id, path}) => {
     }
 
     async function getItem() {
-      const { data } = await axios.get(`http://dkan/api/1/metastore/schemas/dataset/items/${id}?show-reference-ids`);
+      const { data } = await axios.get(`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/dataset/items/${id}?show-reference-ids`);
       setItem(data);
     }
     getItem();

--- a/src/templates/home/index.jsx
+++ b/src/templates/home/index.jsx
@@ -19,11 +19,11 @@ const Home = () => {
 
   React.useEffect(() => {
     async function getDatasets() {
-      const {data} = await axios.get(`http://dkan/api/1/metastore/schemas/dataset/items?show-reference-ids`)
+      const {data} = await axios.get(`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/dataset/items?show-reference-ids`)
       setDatasets(data);
     }
     async function getThemes() {
-      const {data} = await axios.get(`http://dkan/api/1/metastore/schemas/theme/items`)
+      const {data} = await axios.get(`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/theme/items`)
       setThemes(data);
     }
     if (datasets === null) {

--- a/src/templates/search/index.jsx
+++ b/src/templates/search/index.jsx
@@ -10,7 +10,7 @@ const SearchTemplate = ({path}) => {
     <div className={`dc-page ${config.container}`}>
         <h1>Datasets</h1>
         <Search
-          searchEndpoint={`http://dkan/api/1/search`}
+          searchEndpoint={`${process.env.REACT_APP_ROOT_URL}/search`}
           defaultFacets={defaultFacets}
           sortOptions={sortOptions}
           setSearchUrl={true}


### PR DESCRIPTION
This PR addresses #17 
In Gatsby we needed a Gatsby and dynamic url in the .env files, but since the app is now entirely dynamic, we will just need a full path for the development site since it loads at `localhost:3000` and a relative for the actual build since it will be served at the root of the Drupal site. 

QA Steps:
1. `yarn start` to test .env.development file
1. `yarn build` to build a production ready version of the site to test .env.production file
1. `serve build` or equivalent if you have a local node server

To use this in a DKAN site, you will need to use this branch of DKAN which allows for other than Gatsby builds: 
https://github.com/GetDKAN/dkan/pull/3157

By default that branch is set to use Gatsby still, so you will need to update Frontend config yml with the following:
```
static: False
build_folder: '/build'
frontend_path: '/<the location of repo in docroot>' 
routes:
  - home,/home
  - about,/about
  - api,/api
  - dataset,/dataset/{id}
  - datasetapi,/dataset/{id}/api
  - search,/search
  - publishers,/publishers 
```