### PR TITLE
Add Dataset API page and Link state to datasets/api

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import SearchTemplate from './templates/search';
 import ApiDocsFull from './templates/api';
 import NotFound from './templates/not_found';
 import Dataset from './templates/dataset';
+import ApiDocsSpecific from './templates/dataset/api';
 import Publishers from './templates/publishers';
 import Layout from './components/Layout';
 import "@civicactions/data-catalog-components/dist/index.css";
@@ -28,6 +29,7 @@ function App() {
         <SearchTemplate path="/search" />
         <ApiDocsFull path="/api" />
         <Dataset path="/dataset/:id" />
+        <ApiDocsSpecific path="/dataset/:id/api" />
       </Router>
     </Layout>
   );

--- a/src/templates/dataset/api.jsx
+++ b/src/templates/dataset/api.jsx
@@ -20,7 +20,7 @@ const ApiDocsSpecific = ({ id, location }) => {
     if(dataset) {
       setLoading(false);
     } else {
-      axios.get('http://dkan.localtest.me/api/1/metastore/schemas/dataset/items/' + id + "?show-reference-ids")
+      axios.get(`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/dataset/items/${id}?show-reference-ids`)
       .then((res) => {
         setItem(res.data);
         setLoading(false);
@@ -74,7 +74,7 @@ const ApiDocsSpecific = ({ id, location }) => {
             <Title title={item.title} />
               <ApiDocs
                 endpoint={
-                  'http://dkan.localtest.me/api/1' +
+                  `${process.env.REACT_APP_ROOT_URL}` +
                   "/metastore/schemas/dataset/items/" +
                   id +
                   "/docs"

--- a/src/templates/dataset/api.jsx
+++ b/src/templates/dataset/api.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Link } from "@reach/router";
+import Loader from "react-loader-advanced";
+import LoadingSpin from "react-loading-spin";
+import {
+  ApiDocs,
+  Title,
+  Organization
+} from "@civicactions/data-catalog-components";
+import config from "../../assets/config";
+import orgs from "../../assets/publishers";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import axios from 'axios';
+
+const ApiDocsSpecific = ({ id, location }) => {
+  const { dataset } = location.state;
+  const [item, setItem] = React.useState(dataset ? dataset : {});
+  const [loading, setLoading] = React.useState(true);
+  React.useEffect(() => {
+    if(dataset) {
+      setLoading(false);
+    } else {
+      axios.get('http://dkan.localtest.me/api/1/metastore/schemas/dataset/items/' + id + "?show-reference-ids")
+      .then((res) => {
+        setItem(res.data);
+        setLoading(false);
+      })
+    }
+  }, [id, dataset])
+
+
+    const orgName = "publisher" in item && item.publisher.data ? item.publisher.data.name : "";
+    const orgDetails = orgs.filter(org => orgName === org.name);
+    const orgImage = orgDetails.length && orgDetails[0].imageUrl ? orgDetails[0].imageUrl : "";
+    const orgDesc = orgDetails.length && orgDetails[0].description ? orgDetails[0].description : "";
+    let renderOrg;
+    if(orgDetails.length > 0 && orgDetails[0].imageUrl) {
+      renderOrg = <Organization name={orgName} imageUrl={orgImage} description={orgDesc}/>;
+    } else {
+      renderOrg = <Organization name={orgName} description={orgDesc}/>;
+    }
+  return (
+    <div className={`dc-dataset-page ${config.container}`}>
+       <Loader
+          backgroundStyle={{ backgroundColor: "#f9fafb" }}
+          foregroundStyle={{ backgroundColor: "#f9fafb" }}
+          show={loading}
+          message={
+            <LoadingSpin width={"3px"} primaryColor={"#007BBC"} />
+          }
+        >
+      <div className="row">
+       
+          <div className="col-md-3 col-sm-12">
+            {renderOrg}
+            <div className="dc-block-wrapper">
+              <FontAwesomeIcon
+                icon={['fas', 'arrow-left']}
+                size="1x"
+                aria-hidden="true"
+                role="presentation"
+              />
+              Back to the{" "}
+              <Link
+                to={`/dataset/${id}`}
+                state={{dataset: {...item}}}
+              >
+                dataset
+              </Link>
+              .
+            </div>
+          </div>
+          <div className="results-list col-md-9 col-sm-12">
+            <Title title={item.title} />
+              <ApiDocs
+                endpoint={
+                  'http://dkan.localtest.me/api/1' +
+                  "/metastore/schemas/dataset/items/" +
+                  id +
+                  "/docs"
+                }
+              />
+          </div>
+        
+      </div>
+      </Loader>
+    </div>
+  );
+}
+
+export default ApiDocsSpecific;

--- a/src/templates/dataset/index.jsx
+++ b/src/templates/dataset/index.jsx
@@ -14,21 +14,26 @@ import {
 } from "@civicactions/data-catalog-components";
 import orgs from "../../assets/publishers";
 
-const Dataset = ({id, path}) => {
-  const [item, setItem] = useState({})
+const Dataset = ({id, path, location}) => {
+  // const item = props.pageContext.dataset;
+  // const path = props.path;
+  const { dataset } = location.state;
+  const [item, setItem] = useState(dataset ? dataset : {})
   const [hasWindow, checkForWindow] = useState(false);
 
   useEffect(() => {
     if (window !== undefined) {
       checkForWindow(true);
     }
-
+    console.log(dataset)
     async function getItem() {
-      const { data } = await axios.get(`http://dkan/api/1/metastore/schemas/dataset/items/${id}?show-reference-ids`);
+      const { data } = await axios.get(`http://dkan.localtest.me/api/1/metastore/schemas/dataset/items/${id}?show-reference-ids`);
       setItem(data);
     }
-    getItem();
-  }, [id]);
+    if (!dataset) {
+      getItem();
+    }
+  }, [id, dataset]);
 
   const orgName =
     "publisher" in item && item.publisher ? item.publisher.data.name : "";
@@ -115,7 +120,12 @@ const Dataset = ({id, path}) => {
             {renderOrg}
             <div className="dc-block-wrapper">
               The information on this page is also available via the{" "}
-              <Link to={`dataset/${item.identifier}/api`}>API</Link>.
+              <Link
+                to={`/dataset/${item.identifier}/api`}
+                state={{ dataset: {...item} }}
+              >
+                API
+              </Link>.
             </div>
           </div>
           <div className="col-md-9 col-sm-12">

--- a/src/templates/dataset/index.jsx
+++ b/src/templates/dataset/index.jsx
@@ -14,9 +14,7 @@ import {
 } from "@civicactions/data-catalog-components";
 import orgs from "../../assets/publishers";
 
-const Dataset = ({id, path, location}) => {
-  // const item = props.pageContext.dataset;
-  // const path = props.path;
+const Dataset = ({id, location}) => {
   const { dataset } = location.state;
   const [item, setItem] = useState(dataset ? dataset : {})
   const [hasWindow, checkForWindow] = useState(false);
@@ -25,7 +23,6 @@ const Dataset = ({id, path, location}) => {
     if (window !== undefined) {
       checkForWindow(true);
     }
-    console.log(dataset)
     async function getItem() {
       const { data } = await axios.get(`http://dkan.localtest.me/api/1/metastore/schemas/dataset/items/${id}?show-reference-ids`);
       setItem(data);


### PR DESCRIPTION
This PR adds the API page to the individual dataset paths. I've also updated both the dataset/api and dataset path to link to each other with Reach Router state. So if a user clicks the links and we have already queried for the dataset, we don't have to query again. This should help speed up render time since it will cut out an API call if someone clicks back and forth between the two pages.

## QA Steps

1. Navegate to any dataset page
2. Confirm it has a working "API" page linked on the sidebar under organization